### PR TITLE
Group blog posts by project in sidebar

### DIFF
--- a/blog/old/2019-05-28-first-blog-post.md
+++ b/blog/old/2019-05-28-first-blog-post.md
@@ -2,6 +2,7 @@
 slug: first-blog-post
 title: First Blog Post
 # authors: [slorber, yangshun]
+project: ProjectA
 tags: [hola, docusaurus]
 ---
 

--- a/blog/old/2019-05-29-long-blog-post.md
+++ b/blog/old/2019-05-29-long-blog-post.md
@@ -2,6 +2,7 @@
 slug: long-blog-post
 title: Long Blog Post
 # authors: yangshun
+project: ProjectA
 tags: [hello, docusaurus]
 ---
 

--- a/blog/old/2021-08-01-mdx-blog-post.mdx
+++ b/blog/old/2021-08-01-mdx-blog-post.mdx
@@ -2,6 +2,7 @@
 slug: mdx-blog-post
 title: MDX Blog Post
 # authors: [slorber]
+project: ProjectB
 tags: [docusaurus]
 ---
 

--- a/blog/old/2021-08-26-welcome/index.md
+++ b/blog/old/2021-08-26-welcome/index.md
@@ -2,6 +2,7 @@
 slug: welcome
 title: Welcome
 # authors: [slorber, yangshun]
+project: ProjectB
 tags: [facebook, hello, docusaurus]
 ---
 

--- a/blog/think/2019-05-28-first-blog-post.md
+++ b/blog/think/2019-05-28-first-blog-post.md
@@ -2,6 +2,7 @@
 slug: first-blog-post
 title: First Blog Post
 # authors: [slorber, yangshun]
+project: ProjectA
 tags: [hola, docusaurus]
 ---
 

--- a/src/data/projectSidebar.js
+++ b/src/data/projectSidebar.js
@@ -1,0 +1,11 @@
+export default {
+  ProjectA: [
+    {title: 'First Blog Post', permalink: '/blog/old/first-blog-post'},
+    {title: 'Long Blog Post', permalink: '/blog/old/long-blog-post'},
+    {title: 'First Blog Post', permalink: '/blog/think/first-blog-post'},
+  ],
+  ProjectB: [
+    {title: 'MDX Blog Post', permalink: '/blog/old/mdx-blog-post'},
+    {title: 'Welcome', permalink: '/blog/old/welcome'},
+  ],
+};

--- a/src/theme/BlogSidebar/Content/index.js
+++ b/src/theme/BlogSidebar/Content/index.js
@@ -1,0 +1,17 @@
+import React, {memo} from 'react';
+import {BlogSidebarItemList} from '@docusaurus/plugin-content-blog/client';
+import categories from '@site/src/data/projectSidebar';
+import styles from '../Desktop/styles.module.css';
+function BlogSidebarContent() {
+  return (
+    <>
+      {Object.entries(categories).map(([project, items]) => (
+        <details className={styles.projectGroup} key={project} open>
+          <summary>{project}</summary>
+          <BlogSidebarItemList items={items} ulClassName="clean-list" />
+        </details>
+      ))}
+    </>
+  );
+}
+export default memo(BlogSidebarContent);

--- a/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/src/theme/BlogSidebar/Desktop/index.tsx
@@ -1,0 +1,23 @@
+import React, {memo, type ReactNode} from 'react';
+import clsx from 'clsx';
+import {translate} from '@docusaurus/Translate';
+import BlogSidebarContent from '@theme/BlogSidebar/Content';
+import type {Props} from '@theme/BlogSidebar/Desktop';
+
+import styles from './styles.module.css';
+
+export default memo(function DesktopWrapper({sidebar}: Props): ReactNode {
+  return (
+    <aside className="col col--3">
+      <nav
+        className={clsx(styles.sidebar, 'thin-scrollbar')}
+        aria-label={translate({
+          id: 'theme.blog.sidebar.navAriaLabel',
+          message: 'Blog sidebar navigation',
+        })}
+      >
+        <BlogSidebarContent />
+      </nav>
+    </aside>
+  );
+});

--- a/src/theme/BlogSidebar/Desktop/styles.module.css
+++ b/src/theme/BlogSidebar/Desktop/styles.module.css
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.sidebar {
+  max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
+  overflow-y: auto;
+  position: sticky;
+  top: calc(var(--ifm-navbar-height) + 2rem);
+}
+
+.projectGroup summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  font-size: var(--ifm-h3-font-size);
+  font-weight: var(--ifm-font-weight-bold);
+}
+
+.projectGroup summary::-webkit-details-marker {
+  display: none;
+}
+
+.projectGroup summary::before {
+  content: '▸';
+  display: inline-block;
+  margin-right: 0.3rem;
+  transition: transform 0.2s ease;
+}
+
+.projectGroup[open] summary::before {
+  transform: rotate(90deg);
+}
+
+.projectGroup > ul {
+  margin-left: 1rem;
+}
+
+
+.sidebarItemList {
+  font-size: 0.9rem;
+}
+
+.sidebarItem {
+  margin-top: 0.7rem;
+}
+
+.sidebarItemLink {
+  color: var(--ifm-font-color-base);
+  display: block;
+}
+
+.sidebarItemLink:hover {
+  text-decoration: none;
+}
+
+.sidebarItemLinkActive {
+  color: var(--ifm-color-primary) !important;
+}
+
+@media (max-width: 996px) {
+  .sidebar {
+    display: none;
+  }
+}
+
+.yearGroupHeading {
+  margin-top: 1.6rem;
+  margin-bottom: 0.4rem;
+}


### PR DESCRIPTION
## Summary
- add `project` frontmatter to posts
- create static project sidebar data
- override sidebar components to display posts grouped by project
- hide `Recent Posts` title and add collapsible project groups

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685577020560832bb63609a32159a420