### PR TITLE
Improve blog sidebar UX

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,7 +88,9 @@ const config = {
       id: 'old',
       routeBasePath: 'blog/old',
       path: './blog/old',
-      authorsMapPath: './blog/authors.yml'
+      authorsMapPath: './blog/authors.yml',
+      blogSidebarCount: 0,
+      blogSidebarTitle: ' ',
     },
   ],
   // /blog/think 경로용
@@ -98,7 +100,9 @@ const config = {
       id: 'think',
       routeBasePath: 'blog/think',
       path: './blog/think',
-      authorsMapPath: './blog/authors.yml'
+      authorsMapPath: './blog/authors.yml',
+      blogSidebarCount: 0,
+      blogSidebarTitle: ' ',
     },
   ],
 ],

--- a/src/theme/BlogSidebar/Content/index.js
+++ b/src/theme/BlogSidebar/Content/index.js
@@ -1,14 +1,33 @@
-import React, {memo} from 'react';
+import React, {memo, useState} from 'react';
 import Heading from '@theme/Heading';
 import {BlogSidebarItemList} from '@docusaurus/plugin-content-blog/client';
 import categories from '@site/src/data/projectSidebar';
+import styles from './styles.module.css';
+
 function BlogSidebarContent() {
+  const [open, setOpen] = useState(() =>
+    Object.fromEntries(Object.keys(categories).map((k) => [k, true])),
+  );
+
+  const toggle = (project) =>
+    setOpen((o) => ({...o, [project]: !o[project]}));
+
   return (
     <>
       {Object.entries(categories).map(([project, items]) => (
         <div role="group" key={project}>
-          <Heading as="h3">{project}</Heading>
-          <BlogSidebarItemList items={items} ulClassName="clean-list" />
+          <Heading as="h3">
+            <button
+              type="button"
+              onClick={() => toggle(project)}
+              className={styles.toggleButton}
+            >
+              {open[project] ? '▼' : '▶'} {project}
+            </button>
+          </Heading>
+          {open[project] && (
+            <BlogSidebarItemList items={items} ulClassName="clean-list" />
+          )}
         </div>
       ))}
     </>

--- a/src/theme/BlogSidebar/Content/styles.module.css
+++ b/src/theme/BlogSidebar/Content/styles.module.css
@@ -1,0 +1,9 @@
+.toggleButton {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}

--- a/src/theme/BlogSidebar/Desktop/index.tsx
+++ b/src/theme/BlogSidebar/Desktop/index.tsx
@@ -13,12 +13,9 @@ export default memo(function DesktopWrapper({sidebar}: Props): ReactNode {
         className={clsx(styles.sidebar, 'thin-scrollbar')}
         aria-label={translate({
           id: 'theme.blog.sidebar.navAriaLabel',
-          message: 'Blog recent posts navigation',
+          message: 'Blog navigation',
         })}
       >
-        <div className={clsx(styles.sidebarItemTitle, 'margin-bottom--md')}>
-          {sidebar.title}
-        </div>
         <BlogSidebarContent />
       </nav>
     </aside>


### PR DESCRIPTION
## Summary
- hide "Recent Posts" title in blog sidebar
- make blog sidebar categories collapsible
- keep sidebars empty to hide recent posts

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_6855806b8b40832b8d8c3ecaec617440